### PR TITLE
Nudge display brightness on return to cros

### DIFF
--- a/chroot-bin/croutoncycle
+++ b/chroot-bin/croutoncycle
@@ -56,6 +56,36 @@ getname() {
     fi
 }
 
+# Local version of brightness command for use with nudgebrightness below
+mybrightness() {
+    local postcmd=''
+    local precmd=''
+    local percent=''
+    local junk=''
+    case "$1" in
+    [0-9]*) precmd='Set'; postcmd="Percent double:$1 int32:${2:-"1"}${2:+"2"}";;
+    *) precmd='Get'; postcmd='Percent'; print='--print-reply';;
+    esac
+
+    host-dbus dbus-send --system --dest=org.chromium.PowerManager \
+        --type=method_call $print /org/chromium/PowerManager \
+        org.chromium.PowerManager.${precmd}ScreenBrightness${postcmd} | {
+            read -r junk
+            read -r double percent
+            echo "${percent}"
+        }
+}
+
+# Nudges brightness down then restores old value, because when chvt-ing back
+# to cros, the brightness is not always correctly restored (host dbus knows
+# correct value but hardware appears to need to be poked)
+nudgebrightness() {
+    local oldbrightness=`mybrightness get`
+    mybrightness $((${oldbrightness%.*} - 1)) &
+    sleep 0.2
+    mybrightness $oldbrightness &
+}
+
 # Only let one instance run at a time to avoid nasty race conditions
 mkdir -m 775 -p "$CROUTONLOCKDIR"
 exec 3>"$CROUTONLOCKDIR/cycle"
@@ -289,7 +319,7 @@ if [ "${destdisp#:}" = "$destdisp" ]; then
         # Raise the right window after chvting, so that it can update
         if [ "$tty" != 'tty1' ]; then
             sudo -n chvt 1
-            brightness down & sleep .2; brightness up &
+            nudgebrightness
         fi
         croutonwmtools raise "${destdisp%"*"}"
     elif [ "${freonowner:-0}" != 0 ]; then
@@ -307,7 +337,7 @@ else
     if xprop -root 'CROUTON_XMETHOD' 2>/dev/null | grep -q '= "xiwi"$'; then
         if [ -z "$freonowner" -a "$tty" != 'tty1' ]; then
             sudo -n chvt 1
-            brightness down & sleep .2; brightness up &
+            nudgebrightness
         elif [ "${freonowner:-0}" != 0 ]; then
             kill -USR1 "$freonowner"
         fi

--- a/chroot-bin/croutoncycle
+++ b/chroot-bin/croutoncycle
@@ -288,7 +288,7 @@ if [ "${destdisp#:}" = "$destdisp" ]; then
         # Raise the right window after chvting, so that it can update
         if [ "$tty" != 'tty1' ]; then
             sudo -n chvt 1
-            sleep .1
+            brightness down & sleep .2; brightness up &
         fi
         croutonwmtools raise "${destdisp%"*"}"
     elif [ "${freonowner:-0}" != 0 ]; then
@@ -306,7 +306,7 @@ else
     if xprop -root 'CROUTON_XMETHOD' 2>/dev/null | grep -q '= "xiwi"$'; then
         if [ -z "$freonowner" -a "$tty" != 'tty1' ]; then
             sudo -n chvt 1
-            sleep .1
+            brightness down & sleep .2; brightness up &
         elif [ "${freonowner:-0}" != 0 ]; then
             kill -USR1 "$freonowner"
         fi


### PR DESCRIPTION
For some targets, when croutoncycling back to cros, the display brightness is not restored correctly - the host cros dbus server knows the correct value but the hardware does not (observed on Toshiba B3340). This admittedly hacky change nudges the the display brightness so that the old correct value is restored.